### PR TITLE
코인 선택시 orderbook component 깜박이는 버그 수정

### DIFF
--- a/src/store/sagas/coin.ts
+++ b/src/store/sagas/coin.ts
@@ -177,10 +177,12 @@ export function* changeCandleDataSaga({ payload }: PayloadAction<{ type: CandleT
 }
 
 function* changeSelectedCoinSaga({ payload }: PayloadAction<{ marketName: string; code: string }>) {
-  yield loadSelectedCoinDataSaga(payload.code);
-  yield loadTradeListSaga(payload.code);
-  yield loadOrderbookSaga([payload.code]);
-  yield loadCandleDataSaga(payload.code);
+  yield all([
+    loadSelectedCoinDataSaga(payload.code),
+    loadTradeListSaga(payload.code),
+    loadOrderbookSaga([payload.code]),
+    loadCandleDataSaga(payload.code),
+  ]);
   yield put(changeSelectedMarketName({ marketName: payload.marketName }));
 }
 


### PR DESCRIPTION
# 개요
코인 선택시 orderbook component 깜박이는 버그 수정

# 내용
기존코드는 코인 데이터와 orderbook 데이터가 동기적으로 받아져서 orderbook component에 들어가는 데이터가 깜박이는 버그가 생김.

그래서 코인데이터와 orderbook 데이터를 병행적으로 처리하기 위해서 saga effect중에서 all을 사용하여서 병행적으로 데이터를 받아온뒤 task를 동시에 실행하게 해서 문제를 해결하였음.